### PR TITLE
fix: ensure lyric prompts have at least 3 words

### DIFF
--- a/src/utils/get_lyrics.ts
+++ b/src/utils/get_lyrics.ts
@@ -120,15 +120,28 @@ async function getSongWithLyrics(random?: boolean) {
       continue;
     }
 
-    // If random is true, pick a random line from the lyrics
     let outputLyrics = lyrics;
+
     if (random) {
       const lines = lyrics
         .split("\n")
         .map((line) => line.trim())
         .filter((line) => line.length > 0);
 
-      outputLyrics = lines[Math.floor(Math.random() * lines.length)] || "";
+      const goodLines = lines.filter(
+        (line) => line.split(/\s+/).filter(Boolean).length >= 3
+      );
+
+      if (goodLines.length === 0) {
+        console.warn(
+          `⚠️ Attempt ${attempt + 1}: No suitable lines found in ${
+            result.artist
+          } - ${result.song}, retrying...`
+        );
+        continue;
+      }
+
+      outputLyrics = goodLines[Math.floor(Math.random() * goodLines.length)];
     }
 
     return {

--- a/src/utils/get_lyrics.ts
+++ b/src/utils/get_lyrics.ts
@@ -111,11 +111,11 @@ async function getSongWithLyrics(random?: boolean) {
     }
 
     const lyrics = await getLyrics(result.artist, result.song);
-    if (!lyrics) {
+    if (!lyrics || lyrics.split(/\s+/).filter(Boolean).length < 3) {
       console.warn(
-        `⚠️ Attempt ${attempt + 1}: Lyrics not found for ${result.artist} - ${
-          result.song
-        }, retrying...`
+        `⚠️ Attempt ${attempt + 1}: Lyrics too short or not found for ${
+          result.artist
+        } - ${result.song}, retrying...`
       );
       continue;
     }


### PR DESCRIPTION
## Fixes. (2)
* Filters out lines with fewer than 3 words when generating lyric prompts.
* Improves player experience by ensuring meaningful lyric snippets.

## Commits. (2)
* [retry fetching song if lyrics are too short (<3 words)](https://github.com/myferr/finish-the-lyric/commit/75cae5d3db49e5e61226be06236077998e9950d4)
* [fix: ensure lyric lines have at least 3 word](https://github.com/myferr/finish-the-lyric/commit/d5411344f414b59406aa469131c9ea01f9a4d941)